### PR TITLE
Insight 50 파일 업로드 중 창을 닫아도 collector 에서 업로드 과정이 멈추지 않음

### DIFF
--- a/collector/index.js
+++ b/collector/index.js
@@ -42,6 +42,11 @@ app.post(
   "/process",
   [verifyPayloadIntegrity],
   async function (request, response) {
+    const abortController = new AbortController();
+    response.on('close', () => {
+      abortController.abort();
+    });
+
     const { filename, options = {} } = reqBody(request);
     try {
       const targetFilename = path
@@ -51,7 +56,8 @@ app.post(
         success,
         reason,
         documents = [],
-      } = await processSingleFile(targetFilename, options);
+      } = await processSingleFile(targetFilename, options, abortController.signal);
+      
       response
         .status(200)
         .json({ filename: targetFilename, success, reason, documents });

--- a/collector/processSingleFile/processorWorker.js
+++ b/collector/processSingleFile/processorWorker.js
@@ -1,0 +1,26 @@
+const { workerData, parentPort } = require('worker_threads');
+const path = require('path');
+
+async function runProcessor() {
+  try {
+    const { processorPath, params } = workerData;
+    // 프로세서 모듈 로드
+    const processor = require(path.join(__dirname, processorPath.replace('./', '/')));
+    
+    // 프로세서 실행
+    const result = await processor(params);
+    
+    // 결과를 메인 스레드로 전송
+    parentPort.postMessage(result);
+  } catch (error) {
+    // 오류 발생 시 실패 응답 전송
+    parentPort.postMessage({
+      success: false,
+      reason: error.message,
+      documents: [],
+    });
+  }
+}
+
+// 프로세서 실행
+runProcessor(); 

--- a/frontend/src/components/WorkspaceChat/ChatContainer/DnDWrapper/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/DnDWrapper/index.jsx
@@ -38,6 +38,7 @@ export function DnDFileUploaderProvider({ workspace, children }) {
     window.addEventListener(REMOVE_ATTACHMENT_EVENT, handleRemove);
     window.addEventListener(CLEAR_ATTACHMENTS_EVENT, resetAttachments);
     window.addEventListener(PASTE_ATTACHMENT_EVENT, handlePastedAttachment);
+    Workspace.cancelAllUploads();
 
     return () => {
       window.removeEventListener(REMOVE_ATTACHMENT_EVENT, handleRemove);
@@ -46,6 +47,7 @@ export function DnDFileUploaderProvider({ workspace, children }) {
         PASTE_ATTACHMENT_EVENT,
         handlePastedAttachment
       );
+      Workspace.cancelAllUploads();
     };
   }, []);
 
@@ -176,6 +178,7 @@ export function DnDFileUploaderProvider({ workspace, children }) {
 
       const formData = new FormData();
       formData.append("file", attachment.file, attachment.file.name);
+      formData.append("clientId", Workspace.getClientId());
       Workspace.uploadAndEmbedFile(workspace.slug, formData).then(
         ({ response, data }) => {
           const updates = {

--- a/frontend/src/models/workspace.js
+++ b/frontend/src/models/workspace.js
@@ -238,11 +238,12 @@ const Workspace = {
       .then((res) => res.ok)
       .catch(() => false);
   },
-  uploadFile: async function (slug, formData) {
+  uploadFile: async function (slug, formData, signal) {
     const response = await fetch(`${API_BASE}/workspace/${slug}/upload`, {
       method: "POST",
       body: formData,
       headers: baseHeaders(),
+      signal: signal,
     });
 
     const data = await response.json();

--- a/frontend/src/models/workspace.js
+++ b/frontend/src/models/workspace.js
@@ -440,17 +440,24 @@ const Workspace = {
    * @returns {Promise<{response: {ok: boolean}, data: {success: boolean, error: string|null, document: {id: string, location:string}|null}}>}
    */
   uploadAndEmbedFile: async function (slug, formData) {
-    const response = await fetch(
-      `${API_BASE}/workspace/${slug}/upload-and-embed`,
-      {
-        method: "POST",
-        body: formData,
-        headers: baseHeaders(),
+    try {
+      const response = await fetch(
+        `${API_BASE}/workspace/${slug}/upload-and-embed`,
+        {
+          method: "POST",
+          body: formData,
+          headers: baseHeaders(),
+        }
+      );
+      
+      const data = await response.json();
+      return { response, data };
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        console.log('업로드가 취소되었습니다.');
       }
-    );
-
-    const data = await response.json();
-    return { response, data };
+      throw error;
+    }
   },
 
   /**
@@ -471,6 +478,29 @@ const Workspace = {
     return response.ok;
   },
   threads: WorkspaceThread,
+  // 클라이언트 ID 생성 및 관리
+  getClientId: function() {
+    let clientId = localStorage.getItem('anythingllm_client_id');
+    if (!clientId) {
+      clientId = `client_${Math.random().toString(36).substring(2, 15)}`;
+      localStorage.setItem('anythingllm_client_id', clientId);
+    }
+    return clientId;
+  },
+  // 현재 클라이언트와 관련된 모든 업로드를 취소합니다.
+  cancelAllUploads: async function() {
+    try {
+      const clientId = this.getClientId();
+      return await fetch(`${API_BASE}/workspace/cancel-uploads`, {
+        method: 'POST',
+        headers: baseHeaders(),
+        body: JSON.stringify({ clientId }),
+      }).then(res => res.ok);
+    } catch (error) {
+      console.error('업로드 취소 중 오류:', error);
+      return false;
+    }
+  }
 };
 
 export default Workspace;

--- a/server/endpoints/api/document/index.js
+++ b/server/endpoints/api/document/index.js
@@ -84,6 +84,12 @@ function apiDocumentEndpoints(app) {
     }
     */
       try {
+        const abortController = new AbortController();
+        const handleAbort = () => {
+          abortController.abort();
+        };
+        response.on('close', handleAbort);
+
         const Collector = new CollectorApi();
         const { originalname } = request.file;
         const processingOnline = await Collector.online();
@@ -100,7 +106,7 @@ function apiDocumentEndpoints(app) {
         }
 
         const { success, reason, documents } =
-          await Collector.processDocument(originalname);
+          await Collector.processDocument(originalname, abortController.signal);
         if (!success) {
           response
             .status(500)
@@ -204,6 +210,12 @@ function apiDocumentEndpoints(app) {
       }
       */
       try {
+        const abortController = new AbortController();
+        const handleAbort = () => {
+          abortController.abort();
+        };
+        response.on('close', handleAbort);
+
         const { originalname } = request.file;
         let folder = request.params?.folderName || "custom-documents";
         folder = normalizePath(folder);
@@ -231,7 +243,7 @@ function apiDocumentEndpoints(app) {
 
         // Process the uploaded document
         const { success, reason, documents } =
-          await Collector.processDocument(originalname);
+          await Collector.processDocument(originalname, abortController.signal);
         if (!success) {
           response
             .status(500)

--- a/server/endpoints/workspaces.js
+++ b/server/endpoints/workspaces.js
@@ -115,6 +115,12 @@ function workspaceEndpoints(app) {
       handleFileUpload,
     ],
     async function (request, response) {
+      const abortController = new AbortController();
+      const handleAbort = () => {
+        abortController.abort();
+      };
+      response.on('close', handleAbort);
+
       try {
         const Collector = new CollectorApi();
         const { originalname } = request.file;
@@ -132,7 +138,7 @@ function workspaceEndpoints(app) {
         }
 
         const { success, reason } =
-          await Collector.processDocument(originalname);
+          await Collector.processDocument(originalname, abortController.signal);
         if (!success) {
           response.status(500).json({ success: false, error: reason }).end();
           return;
@@ -879,6 +885,12 @@ function workspaceEndpoints(app) {
     ],
     async function (request, response) {
       try {
+        const abortController = new AbortController();
+        const handleAbort = () => {
+          abortController.abort();
+        };
+        response.on('close', handleAbort);
+
         const { slug = null } = request.params;
         const user = await userFromSession(request, response);
         const currWorkspace = multiUserMode(response)
@@ -906,7 +918,7 @@ function workspaceEndpoints(app) {
         }
 
         const { success, reason, documents } =
-          await Collector.processDocument(originalname);
+          await Collector.processDocument(originalname, abortController.signal);
         if (!success || documents?.length === 0) {
           response.status(500).json({ success: false, error: reason }).end();
           return;

--- a/server/endpoints/workspaces.js
+++ b/server/endpoints/workspaces.js
@@ -35,6 +35,8 @@ const { WorkspaceThread } = require("../models/workspaceThread");
 const truncate = require("truncate");
 const { purgeDocument } = require("../utils/files/purgeDocument");
 
+const activeUploads = new Map(); // clientId -> Set of AbortControllers
+
 function workspaceEndpoints(app) {
   if (!app) return;
 
@@ -890,7 +892,14 @@ function workspaceEndpoints(app) {
           abortController.abort();
         };
         response.on('close', handleAbort);
-
+        
+        const clientId = request.body.clientId || 'unknown';
+        
+        if (!activeUploads.has(clientId)) {
+          activeUploads.set(clientId, new Set());
+        }
+        activeUploads.get(clientId).add(abortController);
+        
         const { slug = null } = request.params;
         const user = await userFromSession(request, response);
         const currWorkspace = multiUserMode(response)
@@ -948,6 +957,14 @@ function workspaceEndpoints(app) {
             .status(200)
             .json({ success: false, error: errors?.[0], document: null });
 
+        // 업로드 완료 후 컨트롤러 제거
+        if (activeUploads.has(clientId)) {
+          activeUploads.get(clientId).delete(abortController);
+          if (activeUploads.get(clientId).size === 0) {
+            activeUploads.delete(clientId);
+          }
+        }
+        
         response.status(200).json({
           success: true,
           error: null,
@@ -985,6 +1002,36 @@ function workspaceEndpoints(app) {
       } catch (e) {
         console.error(e.message, e);
         response.sendStatus(500).end();
+      }
+    }
+  );
+
+  app.post(
+    "/workspace/cancel-uploads",
+    [validatedRequest, flexUserRoleValid([ROLES.all])],
+    async function (request, response) {
+      try {
+        const { clientId } = reqBody(request);
+        
+        if (activeUploads.has(clientId)) {
+          const controllers = activeUploads.get(clientId);
+          controllers.forEach(controller => {
+            try {
+              if (controller && !controller.signal.aborted) {
+                controller.abort();
+              }
+            } catch (e) {
+              console.error("업로드 취소 중 오류:", e);
+            }
+          });
+          
+          activeUploads.delete(clientId);
+        }
+        
+        response.status(200).json({ success: true });
+      } catch (error) {
+        console.error("업로드 취소 처리 중 오류:", error);
+        response.status(500).json({ success: false, error: error.message });
       }
     }
   );


### PR DESCRIPTION
 - 업로드 창 닫을 시 frontend - server - collector 연결 끊도록 구현
 - server 와 collector의 연결이 끊겼을 시 worker thread를 이용하여 ocr 작업 종료시킬 수 있도록 수정
 - 채팅 창에서 파일 업로드 중 워크스페이스, 쓰레드 등 다른 창으로 이동 시 서버에서 업로드 진행 중지 되도록 수정